### PR TITLE
Support configuring additional server groups for the cluster

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -22,8 +22,9 @@ module "k8s_master" {
   secure_kubelet         = var.secure_kubelet
 
   #Injections
-  cluster_server_group    = module.k8s_cluster.group_id
-  cluster_firewall_policy = module.k8s_cluster.firewall_policy_id
-  ca_cert_pem             = tls_self_signed_cert.k8s_ca.cert_pem
-  ca_private_key_pem      = tls_private_key.k8s_ca.private_key_pem
+  cluster_server_group     = module.k8s_cluster.group_id
+  cluster_firewall_policy  = module.k8s_cluster.firewall_policy_id
+  ca_cert_pem              = tls_self_signed_cert.k8s_ca.cert_pem
+  ca_private_key_pem       = tls_private_key.k8s_ca.private_key_pem
+  additional_server_groups = var.additional_server_groups
 }

--- a/master/main.tf
+++ b/master/main.tf
@@ -89,13 +89,12 @@ resource "brightbox_server" "k8s_master" {
   user_data = local.cloud_config
   zone      = var.master_zone == "" ? "${var.region}-${(count.index % 2 == 0 ? "a" : "b")}" : var.master_zone
 
-  server_groups = [var.cluster_server_group]
+  server_groups = concat([var.cluster_server_group], var.additional_server_groups)
 
   lifecycle {
     ignore_changes = [
       image,
       type,
-      server_groups,
       zone,
     ]
     create_before_destroy = true

--- a/master/variables.tf
+++ b/master/variables.tf
@@ -101,3 +101,9 @@ variable "secure_kubelet" {
   type        = bool
   description = "Whether to ask for a central signing certificate or stick with self-signed"
 }
+
+variable "additional_server_groups" {
+  description = "Additional server group ids to add all cluster nodes to"
+  type        = list(string)
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "secure_kubelet" {
   default     = false
 }
 
+variable "additional_server_groups" {
+  description = "Additional server group ids to add all cluster nodes to"
+  type        = list(string)
+  default     = []
+}
+
 # Masters
 
 variable "master_count" {

--- a/worker.tf
+++ b/worker.tf
@@ -19,12 +19,13 @@ module "k8s_worker" {
   worker_zone            = var.worker_zone
 
   #Injections
-  cluster_server_group = module.k8s_cluster.group_id
-  bastion              = module.k8s_master.bastion
-  bastion_user         = module.k8s_master.bastion_user
-  apiserver_fqdn       = module.k8s_master.apiserver
-  ca_cert_pem          = tls_self_signed_cert.k8s_ca.cert_pem
-  boot_token           = module.k8s_master.boot_token
+  cluster_server_group     = module.k8s_cluster.group_id
+  bastion                  = module.k8s_master.bastion
+  bastion_user             = module.k8s_master.bastion_user
+  apiserver_fqdn           = module.k8s_master.apiserver
+  ca_cert_pem              = tls_self_signed_cert.k8s_ca.cert_pem
+  boot_token               = module.k8s_master.boot_token
+  additional_server_groups = var.additional_server_groups
 }
 
 module "k8s_storage" {
@@ -49,11 +50,11 @@ module "k8s_storage" {
   storage_system         = var.storage_system
 
   #Injections
-  cluster_server_group = module.k8s_cluster.group_id
-  bastion              = module.k8s_master.bastion
-  bastion_user         = module.k8s_master.bastion_user
-  apiserver_fqdn       = module.k8s_master.apiserver
-  ca_cert_pem          = tls_self_signed_cert.k8s_ca.cert_pem
-  boot_token           = module.k8s_master.boot_token
+  cluster_server_group     = module.k8s_cluster.group_id
+  bastion                  = module.k8s_master.bastion
+  bastion_user             = module.k8s_master.bastion_user
+  apiserver_fqdn           = module.k8s_master.apiserver
+  ca_cert_pem              = tls_self_signed_cert.k8s_ca.cert_pem
+  boot_token               = module.k8s_master.boot_token
+  additional_server_groups = var.additional_server_groups
 }
-

--- a/worker/variables.tf
+++ b/worker/variables.tf
@@ -104,3 +104,9 @@ variable "storage_system" {
   description = "Which storage system to setup"
   default     = "manual"
 }
+
+variable "additional_server_groups" {
+  description = "Additional server group ids to add all cluster nodes to"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
All control plane and worker nodes will be added to these groups by terraform on apply. All new worker nodes created by the autoscaler will be added to them (if you're using the most recent autoscaler release which supports this!)

Also, Terraform will no longer ignore outside changes to server_groups so you should make sure that any additional group memberships you've been managing outside of these manifests are configured using the additional_server_groups variable.