### PR TITLE
Ensure cri-tools package is versioned/held

### DIFF
--- a/master.tf
+++ b/master.tf
@@ -9,6 +9,7 @@ module "k8s_master" {
   image_desc             = var.image_desc
   region                 = var.region
   kubernetes_release     = var.kubernetes_release
+  critools_release       = var.critools_release
   calico_release         = var.calico_release
   autoscaler_release     = var.autoscaler_release
   cluster_name           = var.cluster_name

--- a/master/main.tf
+++ b/master/main.tf
@@ -134,7 +134,10 @@ resource "null_resource" "k8s_master_once" {
     inline = [
       templatefile(
         "${local.template_path}/install-packages",
-        { kubernetes_release = var.kubernetes_release }
+        {
+          kubernetes_release = var.kubernetes_release
+          critools_release   = var.critools_release
+        }
       )
     ]
   }
@@ -243,6 +246,7 @@ resource "null_resource" "k8s_master_mirrors_configure" {
     inline = [
       templatefile("${local.template_path}/install-master-mirror", {
         kubernetes_release        = var.kubernetes_release,
+        critools_release          = var.critools_release,
         cluster_fqdn              = local.cluster_fqdn,
         public_fqdn               = local.public_fqdn,
         boot_token                = local.boot_token
@@ -315,6 +319,7 @@ locals {
 
   master_provisioner_script = templatefile("${local.template_path}/install-master", {
     kubernetes_release = var.kubernetes_release,
+    critools_release   = var.critools_release,
     calico_release     = var.calico_release,
     cluster_fqdn       = local.cluster_fqdn,
     public_fqdn        = local.public_fqdn,

--- a/master/templates/install-master
+++ b/master/templates/install-master
@@ -272,6 +272,17 @@ upgrade() {
         $${APT_GET} update
         $${APT_GET} install debconf-utils
         echo "docker.io docker.io/restart select true" | sudo debconf-set-selections
+        # Upgrade cri-tools before upgrading kubeadm to avoid CRI API incompatibility
+        echo "Upgrading cri-tools"
+        if ! retry 5 sudo apt-get -qq -y --allow-change-held-packages --allow-downgrades install cri-tools=${critools_release}-00
+        then
+                sudo apt-mark hold cri-tools
+                echo "Failed to install cri-tools at version ${critools_release}-00"
+                echo "Version installed is at $(dpkg-query --showformat='$${Version}' --show cri-tools)"
+                return 2
+        fi
+        sudo apt-mark hold cri-tools
+        echo "Upgrading kubeadm"
         if ! retry 5 $${APT_GET} --allow-change-held-packages --allow-downgrades install kubeadm=${kubernetes_release}-00
         then
                 sudo apt-mark hold kubeadm

--- a/master/templates/install-master-mirror
+++ b/master/templates/install-master-mirror
@@ -217,6 +217,16 @@ upgrade() {
         $${APT_GET} update 
         $${APT_GET} install debconf-utils
 	echo "docker.io docker.io/restart select true" | sudo debconf-set-selections
+	# Upgrade cri-tools before upgrading kubeadm to avoid CRI API incompatibility
+	echo "Upgrading cri-tools"
+	if ! retry 5 sudo apt-get -qq -y --allow-change-held-packages install cri-tools=${critools_release}-00
+	then
+		sudo apt-mark hold cri-tools
+		echo "Failed to install cri-tools at version ${critools_release}-00"
+		echo "Version installed is at $(dpkg-query --showformat='$${Version}' --show cri-tools)"
+		exit 2
+	fi
+	sudo apt-mark hold cri-tools
 	echo "Upgrading kubeadm"
 	if ! retry 5 $${APT_GET} --allow-change-held-packages install kubeadm=${kubernetes_release}-00
 	then

--- a/master/templates/install-packages
+++ b/master/templates/install-packages
@@ -19,6 +19,7 @@ $${APT_GET} update
 $${APT_GET} install \
     containerd.io \
 	kubeadm=${kubernetes_release}-00 \
-        kubectl=${kubernetes_release}-00 \
-	kubelet=${kubernetes_release}-00
-sudo apt-mark hold kubeadm kubectl kubelet
+	kubectl=${kubernetes_release}-00 \
+	kubelet=${kubernetes_release}-00 \
+	cri-tools=${critools_release}-00
+sudo apt-mark hold kubeadm kubectl kubelet cri-tools

--- a/master/variables.tf
+++ b/master/variables.tf
@@ -8,6 +8,11 @@ variable "kubernetes_release" {
   description = "Version of Kubernetes to install"
 }
 
+variable "critools_release" {
+  type        = string
+  description = "Version of cri-tools to install"
+}
+
 variable "calico_release" {
   type        = string
   description = "Version of Calico to install"

--- a/variables.tf
+++ b/variables.tf
@@ -189,6 +189,12 @@ variable "kubernetes_release" {
   default     = "1.25.6"
 }
 
+variable "critools_release" {
+  type        = string
+  description = "Version of cri-tools to install"
+  default     = "1.25.0"
+}
+
 variable "autoscaler_release" {
   type        = string
   description = "Version of Vertical Autoscaler to install if the scaling features are activated. This needs to be the same minor version as the k8s release"

--- a/worker.tf
+++ b/worker.tf
@@ -12,6 +12,7 @@ module "k8s_worker" {
   image_desc             = var.image_desc
   region                 = var.region
   kubernetes_release     = var.kubernetes_release
+  critools_release       = var.critools_release
   internal_cluster_fqdn  = local.cluster_fqdn
   apiserver_service_port = local.service_port
   worker_drain_timeout   = var.worker_drain_timeout
@@ -42,6 +43,7 @@ module "k8s_storage" {
   image_desc             = var.image_desc
   region                 = var.region
   kubernetes_release     = var.kubernetes_release
+  critools_release       = var.critools_release
   internal_cluster_fqdn  = local.cluster_fqdn
   apiserver_service_port = local.service_port
   worker_drain_timeout   = var.worker_drain_timeout

--- a/worker/main.tf
+++ b/worker/main.tf
@@ -2,12 +2,16 @@ locals {
   template_path = "${path.module}/templates"
   upgrade_script = templatefile(
     "${local.template_path}/upgrade-worker",
-    { kubernetes_release = var.kubernetes_release }
+    {
+      kubernetes_release = var.kubernetes_release
+      critools_release   = var.critools_release
+    }
   )
   user_data = templatefile(
     "${local.template_path}/install-worker-userdata",
     {
       kubernetes_release        = var.kubernetes_release
+      critools_release          = var.critools_release
       boot_token                = var.boot_token
       fqdn                      = var.apiserver_fqdn
       service_port              = var.apiserver_service_port

--- a/worker/templates/install-worker-userdata
+++ b/worker/templates/install-worker-userdata
@@ -8,6 +8,7 @@ ${certificate_authority_pem}
 CA
 )
 k8s_version="${kubernetes_release}"
+critools_version="${critools_release}"
 kubeadm_join_command="kubeadm join --config /tmp/kubeadm.conf"
 storage_system="${storage_system}"
 openebs_mount='/var/openebs/local'
@@ -95,9 +96,10 @@ apt-get -qq -y install \
 	glusterfs-client \
 	kubeadm=$${k8s_version}-00 \
 	kubectl=$${k8s_version}-00 \
-	kubelet=$${k8s_version}-00
+	kubelet=$${k8s_version}-00 \
+	cri-tools=$${critools_version}-00
 
-apt-mark hold kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl cri-tools
 
 echo "Selecting iptables version"
 if update-alternatives --set iptables /usr/sbin/iptables-legacy

--- a/worker/templates/upgrade-worker
+++ b/worker/templates/upgrade-worker
@@ -63,6 +63,16 @@ ensure_updated_apt_keys
 $${APT_GET} update
 $${APT_GET} install debconf-utils lvm2 nfs-common
 echo "docker.io docker.io/restart select true" | sudo debconf-set-selections
+# Upgrade cri-tools before upgrading kubeadm to avoid CRI API incompatibility
+echo "Upgrading cri-tools"
+if ! retry 5 sudo apt-get -qq -y --allow-change-held-packages --allow-downgrades install cri-tools="${critools_release}-00"
+then
+	sudo apt-mark hold cri-tools
+	echo "Failed to install cri-tools at version ${critools_release}-00"
+	echo "Version installed is at $(dpkg-query --showformat='$${Version}' --show cri-tools)"
+	return 2
+fi
+sudo apt-mark hold cri-tools
 echo "Upgrading kubeadm"
 if ! retry 5 $${APT_GET} --allow-change-held-packages --allow-downgrades install kubeadm="${kubernetes_release}-00"
 then

--- a/worker/variables.tf
+++ b/worker/variables.tf
@@ -13,6 +13,11 @@ variable "kubernetes_release" {
   description = "Version of Kubernetes to install"
 }
 
+variable "critools_release" {
+  type        = string
+  description = "Version of cri-tools to install"
+}
+
 variable "root_size" {
   type        = number
   description = "The size of the worker root partition in GiB (0 for full size)"


### PR DESCRIPTION
The `cri-tools` packages are released roughly in lockstep with kubernetes minor releases. It's possible to run into compatibility issues between `kubeadm` and `cri-tools` when they're not matched (e.g. CRI v1beta1 API deprecation).

These changes ensure the specified `cri-tools` package is installed and held during master/worker installs and upgrades.