### PR TITLE
Ensure upstream config changes don't block master install-packages script

### DIFF
--- a/master/templates/install-packages
+++ b/master/templates/install-packages
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -e
-APT_GET="sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_SUSPEND=1 apt-get -qq -y"
+APT_GET="sudo DEBIAN_FRONTEND=noninteractive NEEDRESTART_SUSPEND=1 apt-get -o Dpkg::Options::=--force-confold -o Dpkg::Options::=--force-confdef -qq -y"
 
 echo "Waiting for base package installation to complete"
 cloud-init status --wait >/dev/null


### PR DESCRIPTION
Usually the master `install-packages` script is only run once during initial cluster setup. However, if the script is changed (e.g. when switching containerd.io repo) and related terraform resources become tainted as a result, it's possible for it to be run again.

In cases where this occurs and one of the upstream packages has changed a config file which is locally modified, it's possible for apt-get to stall due to interactive questions about how to handle the config change.

This fix sets the `--force-confold` and `--force-confdef` dpkg options for apt-get to prevent it asking questions interactively; it will maintain the existing config by default.