### PR TITLE
Update provide dependencies

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -79,7 +79,6 @@ resource "tls_private_key" "k8s_ca" {
 }
 
 resource "tls_self_signed_cert" "k8s_ca" {
-  key_algorithm   = tls_private_key.k8s_ca.algorithm
   private_key_pem = tls_private_key.k8s_ca.private_key_pem
 
   subject {

--- a/worker/versions.tf
+++ b/worker/versions.tf
@@ -8,10 +8,6 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 3.2"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = "~> 2.1"
-    }
   }
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
Remove the obsolete template provider
Update tls provider to version 4.

Upstream changelog notes:

"resource/tls_self_signed_cert: private_key_pem attribute is now stored in the state as-is; first apply may result in an update-in-place"

This is likely to update the CA certificate in place, and may require a control plane restart.

Fixes #16