### PR TITLE
Make download-config.sh BSD compatible

### DIFF
--- a/scripts/download-config.sh
+++ b/scripts/download-config.sh
@@ -2,6 +2,7 @@
 # Download the config from the current cluster to the kubectl config
 # area on the current workstation
 set -e
-mkdir -p $HOME/.kube
-scp ubuntu@$(terraform output -raw bastion):.kube/config ~/.kube/config
-sed -i "s/https:.*$/https:\/\/$(terraform output -raw master):6443/" ~/.kube/config
+mkdir -p "${HOME}/.kube"
+scp "ubuntu@$(terraform output -raw bastion):.kube/config" "${HOME}/.kube/config"
+sed -i.orig "s/https:.*$/https:\/\/$(terraform output -raw master):6443/" "${HOME}/.kube/config"
+rm "${HOME}/.kube/config.orig"


### PR DESCRIPTION
Mac uses BSD sed which has a slightly different syntax for in place editing.

Updated the script so it will work with both GNU sed and BSD sed.

Fixes #20